### PR TITLE
Handle pre/postprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,16 +3765,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minilp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4606,7 +4596,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -6042,15 +6031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
  "thiserror",
-]
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "itertools 0.12.1",
  "num-bigint",
  "once_cell",
+ "reqwest",
  "scarb",
  "scarb-metadata 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scarb-ui 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -573,6 +574,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -3764,6 +3766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minilp"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4595,6 +4607,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -6030,6 +6043,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878a167baa8afd137494101a688ef8c67125089ff2249284bd2b5f9bfedb815"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ petgraph = "0.6.4"
 prost = "0.12.3"
 prost-types = "0.12.3"
 rayon = "1.8.1"
-reqwest = { version = "0.11.23", features = ["blocking", "json", "multipart"] }
+reqwest = { version = "0.11.23", features = ["blocking", "json"] }
 scarb = { git = "https://github.com/software-mansion/scarb.git", rev = "v2.7.0" }
 scarb-metadata = "1.12.0"
 scarb-ui = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ petgraph = "0.6.4"
 prost = "0.12.3"
 prost-types = "0.12.3"
 rayon = "1.8.1"
-reqwest = { version = "0.11.23", features = ["blocking", "json"] }
+reqwest = { version = "0.11.23", features = ["blocking", "json", "multipart"] }
 scarb = { git = "https://github.com/software-mansion/scarb.git", rev = "v2.7.0" }
 scarb-metadata = "1.12.0"
 scarb-ui = "0.1.5"

--- a/cairo-hints/Cargo.toml
+++ b/cairo-hints/Cargo.toml
@@ -58,7 +58,6 @@ cairo-lang-test-plugin = { workspace = true }
 reqwest = { workspace = true }
 handlebars = "6.0.0"
 cainome-cairo-serde = { workspace = true }
-tokio = "1.35.1"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/cairo-hints/Cargo.toml
+++ b/cairo-hints/Cargo.toml
@@ -55,8 +55,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 cairo-lang-hints-test-runner = { workspace = true }
 cairo-lang-test-plugin = { workspace = true }
+reqwest = { workspace = true }
 handlebars = "6.0.0"
 cainome-cairo-serde = { workspace = true }
+tokio = "1.35.1"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
An agent can have pre- or post-processing. This is the logic called before or after the execution of a Cairo program. This is useful for not transmitting or returning a large and complex data structure in the Cairo program, but only the data that the Cairo program needs to perform the verifiable computation. 

Pre/post-processing was added by Gonzalo on OrionRunner. However, when developing an agent, we should avoid using OrionRunner as it's adding overhead in the DX. This PR introduces the pre/post-processing mechanism in cairo-hints. 

If you pass `--preprocess` or `--postprocess` flags, `scarb hints-run` will run the respective endpoints. By default, these endpoints are localhosts, but you can change them with env variables `PREPROCESS_URL` and `POSRPROCESS_URL`. 

The pre-processing input is a JSON string, which you pass with `--args_json`. 

This way, you can E2E-test your agent directly with scarb hints.